### PR TITLE
implement filter and fix outdated docs

### DIFF
--- a/src/Stack.elm
+++ b/src/Stack.elm
@@ -3,12 +3,12 @@ module Stack exposing
   , empty, isEmpty, size
   , toList, fromList
   , pop, push, peek, member
-  , append, concat, map
+  , append, concat, map, filter
   )
 
 {-| A basic implementaion of a generic Stack data strucutre.
 
-@docs Stack, empty, isEmpty, size, toList, fromList, pop, push, peek, member, append, concat, map
+@docs Stack, empty, isEmpty, size, toList, fromList, pop, push, peek, member, append, concat, map, filter
 -}
 
 {-| A generic stack definition.
@@ -152,10 +152,13 @@ concat : List (Stack a) -> Stack a
 concat = List.foldr append empty
 
 {-| Given a function `(a -> b)` and a `Stack a` return a new
-    `Stack b` with the function applied to every element of the stack.
+    `Stack b` with the function applied to every element of the stack. Similar to `List.map`
 
       Stack.fromList [1, 2, 3]
         |> Stack.map ((+) 1)      => Stack 3 [2, 3, 4]
+
+      Stack.fromList [1, 2, 3]
+        |> Stack.map String.fromInt      => Stack 3 ["1", "2", "3"]
 -}
 map : (a -> b) -> Stack a -> Stack b
 map f (Stack count xs) =
@@ -163,7 +166,8 @@ map f (Stack count xs) =
     |> Stack count
 
 
-{-| Filter items within stack, similar to `List.filter`
+{-| Give a predicate function `(a -> Bool)` and a `Stack a` return a new
+    `Stack a` with only the elements in which the predicate function returns `True`. Similar to `List.filter`.
 
       Stack.fromList [1, 2, 3]
         |> Stack.filter ((<) 1)      => Stack 2 [2, 3]

--- a/src/Stack.elm
+++ b/src/Stack.elm
@@ -166,7 +166,7 @@ map f (Stack count xs) =
     |> Stack count
 
 
-{-| Give a predicate function `(a -> Bool)` and a `Stack a` return a new
+{-| Given a predicate function `(a -> Bool)` and a `Stack a` return a new
     `Stack a` with only the elements in which the predicate function returns `True`. Similar to `List.filter`.
 
       Stack.fromList [1, 2, 3]

--- a/src/Stack.elm
+++ b/src/Stack.elm
@@ -1,4 +1,4 @@
-module Stack exposing 
+module Stack exposing
   ( Stack
   , empty, isEmpty, size
   , toList, fromList
@@ -25,7 +25,7 @@ empty = Stack 0 []
     or `False` if `Stack` has one or more elements.
 
       Stack.isEmpty Stack.empty => True
-      
+
       List.range 1 10
         |> Stack.fromList
         |> Stack.isEmpty        => False
@@ -37,8 +37,8 @@ isEmpty (Stack _ xs) =
 {-| Returns how many elements are in the `Stack` as an `Int`.
 
       Stack.size Stack.empty     => 0
-      
-      Stack.fromList [1, 2, 3] 
+
+      Stack.fromList [1, 2, 3]
         |> Stack.size            => 3
 -}
 size : Stack a -> Int
@@ -47,7 +47,7 @@ size (Stack count _) = count
 {-| Given a `Stack`, returns a list where the head of the list
     is the first element on top of the stack.
 
-      Stack.toList Stack.empty => [] 
+      Stack.toList Stack.empty => []
 
       Stack.empty
         |> Stack.push "foo"
@@ -62,27 +62,27 @@ toList (Stack _ xs) = xs
 
       Stack.fromList []        => Stack []
 
-      Stack.fromList [1, 2, 3] => Stack [1, 2, 3]
+      Stack.fromList [1, 2, 3] => Stack 3 [1, 2, 3]
 -}
 fromList : List a -> Stack a
-fromList xs = 
+fromList xs =
   Stack (List.length xs) xs
 
 {-| Given a `Stack`, returns a `Tuple`.
-    The first element is `Just` the element on top of 
+    The first element is `Just` the element on top of
     the stack or `Nothing` if the stack is empty.
     The second element is a new `Stack` without the top of the stack
     or an empty `Stack` if the given `Stack` was empty.
 
-      Stack.pop Stack.empty     => (Nothing, Stack.empty) 
+      Stack.pop Stack.empty     => (Nothing, Stack.empty)
 
-      Stack.fromList [1, 2, 3]  
-        |> Stack.pop            => (Just 1, Stack [2, 3]) 
+      Stack.fromList [1, 2, 3]
+        |> Stack.pop            => (Just 1, Stack 2 [2, 3])
 -}
 pop : Stack a -> (Maybe a, Stack a)
 pop (Stack count xs) =
   case xs of
-    [] -> 
+    [] ->
       (Nothing, empty)
 
     x :: tail ->
@@ -91,10 +91,10 @@ pop (Stack count xs) =
 {-| Given a value `a` and a `Stack a`, push the element onto
     the top of the `Stack`.
 
-      Stack.push "foo" Stack.empty  => Stack ["foo"]
+      Stack.push "foo" Stack.empty  => Stack 1 ["foo"]
 
       Stack.fromList ["foo", "bar"]
-        |> Stack.push "bazz"        => Stack ["bazz", "foo", "bar"]
+        |> Stack.push "bazz"        => Stack 3 ["bazz", "foo", "bar"]
 -}
 push : a -> Stack a -> Stack a
 push v (Stack count xs) =
@@ -104,7 +104,7 @@ push v (Stack count xs) =
     `Nothing` if the `Stack` is empty.
 
       Stack.peek Stack.empty    => Nothing
-      
+
       Stack.fromList [1, 2, 3]
         |> Stack.peek           => Just 1
 -}
@@ -118,7 +118,7 @@ peek (Stack _ xs) =
       Stack.member "foobar" Stack.empty   => False
 
       Stack.fromList ["Mon", "Tues", "Wed", "Thurs", "Fri"]
-        |> Stack.member "Thurs"           => True 
+        |> Stack.member "Thurs"           => True
 -}
 member : a -> Stack a -> Bool
 member sought (Stack _ xs) =
@@ -134,30 +134,54 @@ member sought (Stack _ xs) =
 -}
 append : Stack a -> Stack a -> Stack a
 append (Stack xsCount xs) (Stack ysCount ys) =
-  List.append xs ys 
+  List.append xs ys
     |> Stack (xsCount + ysCount)
 
 {-| Given a list of stacks, join them together where the top of the first
     `Stack` in the given list is the top of the returned `Stack`.
 
-      stacks = 
+      stacks =
         [ Stack.fromList [1, 2]
         , Stack.fromList [3, 4]
         , Stack.fromList [5, 6]
         ]
 
-      Stack.concat stacks      => Stack [1, 2, 3, 4, 5, 6]
+      Stack.concat stacks      => Stack 6 [1, 2, 3, 4, 5, 6]
 -}
 concat : List (Stack a) -> Stack a
-concat = List.foldr append empty 
+concat = List.foldr append empty
 
-{-| Given a function `(a -> b)` and a `Stack a` return a new 
+{-| Given a function `(a -> b)` and a `Stack a` return a new
     `Stack b` with the function applied to every element of the stack.
 
-      Stack.fromList [1, 2, 3] 
-        |> Stack.map ((+) 1)      => Stack [2, 3, 4]
+      Stack.fromList [1, 2, 3]
+        |> Stack.map ((+) 1)      => Stack 3 [2, 3, 4]
 -}
 map : (a -> b) -> Stack a -> Stack b
 map f (Stack count xs) =
   List.map f xs
     |> Stack count
+
+
+{-| Filter items within stack, similar to `List.filter`
+
+      Stack.fromList [1, 2, 3]
+        |> Stack.filter ((<) 1)      => Stack 2 [2, 3]
+
+-}
+filter : (a -> Bool) -> Stack a -> Stack a
+filter f (Stack _ xs) =
+    let
+        ( count, newList ) =
+            List.foldr
+                (\a ( c, items ) ->
+                    if f a then
+                        ( c + 1, a :: items )
+
+                    else
+                        ( c, items )
+                )
+                ( 0, [] )
+                xs
+    in
+    Stack count newList

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -19,13 +19,13 @@ both : (a -> b) -> (a, a) -> (b, b)
 both f (x, y) = (f x, f y)
 
 tests : Test
-tests = 
-  describe "Stack tests" 
-    [ describe "empty" 
-        [ test "has a size of 0" <| 
+tests =
+  describe "Stack tests"
+    [ describe "empty"
+        [ test "has a size of 0" <|
             \() ->
                 Stack.size Stack.empty |> Expect.equal 0
-        
+
         , test "encapsulates an empty list" <|
             \() ->
                 Expect.true
@@ -33,13 +33,13 @@ tests =
                   (Stack.toList Stack.empty |> List.isEmpty)
         ]
 
-    , describe "isEmpty" 
+    , describe "isEmpty"
         [ test "returns true for an empty stack" <|
             \() ->
                 Expect.true
                   "empty stack is empty"
                   (Stack.isEmpty Stack.empty)
-        
+
         , fuzz (nonEmptyListFuzzer int) "returns false for a non empty stack" <|
             \xs ->
                 Expect.false
@@ -52,8 +52,8 @@ tests =
                   0
                   (Stack.fromList xs |> Stack.size)
         ]
-    
-    , describe "size" 
+
+    , describe "size"
         [ test "can get a size from a stack constructed using push" <|
             \() ->
                 Stack.empty
@@ -86,19 +86,19 @@ tests =
                   (Stack.fromList xs)
         ]
 
-    , describe "pop" 
+    , describe "pop"
         [ fuzz (nonEmptyListFuzzer int) "popping off the stack is Just the head of the list as the first element of the tuple" <|
             \xs ->
                 Expect.equal
                   (List.head xs)
                   (Stack.fromList xs |> Stack.pop |> Tuple.first)
-      
+
       , fuzz (nonEmptyListFuzzer int) "popping off the stack is Just the tail of the list as the second element of the tuple" <|
             \xs ->
                 Expect.equal
                   (List.tail xs |> Maybe.withDefault [] |> Stack.fromList)
                   (Stack.fromList xs |> Stack.pop |> Tuple.second)
-        
+
         , test "popping on an empty stack yields Nothing as the first element of the tuple" <|
             \() ->
                 Expect.equal
@@ -111,30 +111,30 @@ tests =
                   Stack.empty
                   (Stack.pop Stack.empty |> Tuple.second)
         ]
-      
-      , describe "push" 
+
+      , describe "push"
           [ fuzz (list int) "pushing elements onto a stack has the same length as the original list" <|
               \xs ->
                   Expect.equal
                     (List.length xs)
                     (List.foldr Stack.push Stack.empty xs |> Stack.size)
           ]
-      
-      , describe "peek" 
+
+      , describe "peek"
           [ fuzz (nonEmptyListFuzzer int) "peeking and the head of a list are Just the first element of both" <|
               \xs ->
                   Expect.equal
                     (List.head xs)
                     (Stack.fromList xs |> Stack.peek)
-          
+
           , test "peeking an empty list yields nothing" <|
               \() ->
                   Expect.equal
                     Nothing
                     (Stack.peek Stack.empty)
           ]
-      
-    , describe "member" 
+
+    , describe "member"
         [ fuzz (nonEmptyListFuzzer int) "every member of the list is a member of the stack" <|
             \xs ->
                 let
@@ -142,10 +142,10 @@ tests =
                 in
                   List.all (flip Stack.member stack) xs
                     |> Expect.true "every member of the stack is a member of the list"
-        
+
         , test "an element that is part of the stack yields false" <|
             \() ->
-                List.range 0 10 
+                List.range 0 10
                   |> Stack.fromList
                   |> Stack.member 20
                   |> Expect.false "is not a member of the list"
@@ -156,50 +156,50 @@ tests =
                   |> Stack.member x
                   |> Expect.false "an empty stack has no members"
         ]
-    
-    , describe "append" 
+
+    , describe "append"
         [ fuzz (list int) "appending a list with the second stack as empty is equal to the original stack" <|
             \xs ->
                 Expect.all
-                  [ Expect.equal (Stack.fromList xs) 
+                  [ Expect.equal (Stack.fromList xs)
                   , Expect.equal (Stack.fromList xs |> Stack.size) << Stack.size
                   , Expect.equal (List.head xs) << Stack.peek
                   ]
                   (Stack.append (Stack.fromList xs) Stack.empty)
-          
+
         , fuzz (list int) "appending a list with the first stack as empty is equal to the original stack" <|
             \xs ->
                 Expect.all
-                  [ Expect.equal (Stack.fromList xs) 
+                  [ Expect.equal (Stack.fromList xs)
                   , Expect.equal (Stack.fromList xs |> Stack.size) << Stack.size
                   , Expect.equal (List.head xs) << Stack.peek
                   ]
                   (Stack.append Stack.empty (Stack.fromList xs))
-        
+
         , fuzz (tuple (list int, list int)) "appending two stacks" <|
             \stacks ->
                 Expect.all
-                  [ Expect.equal (uncurry List.append stacks |> Stack.fromList) 
+                  [ Expect.equal (uncurry List.append stacks |> Stack.fromList)
                   , Expect.equal (uncurry List.append stacks |> Stack.fromList |> Stack.size) << Stack.size
                   , Expect.equal (uncurry List.append stacks |> List.head) << Stack.peek
                   ]
                   (both Stack.fromList stacks |> uncurry Stack.append)
-      
+
         , test "appending two stacks empty stacks" <|
             \() ->
                 Expect.all
-                  [ Expect.equal Stack.empty 
+                  [ Expect.equal Stack.empty
                   , Expect.equal (Stack.size Stack.empty) << Stack.size
                   , Expect.equal Nothing << Stack.peek
                   ]
                   (Stack.append Stack.empty Stack.empty)
         ]
-      
+
       , describe "concat"
           [ fuzz (list (list int)) "concating stacks is the same as appending lists together" <|
               \xs ->
                 let
-                  appendedList = List.foldr List.append [] xs 
+                  appendedList = List.foldr List.append [] xs
                 in
                   Expect.all
                     [ Expect.equal (Stack.fromList appendedList)
@@ -207,9 +207,9 @@ tests =
                     , Expect.equal (List.head appendedList) << Stack.peek
                     ]
                     (List.map Stack.fromList xs |> Stack.concat)
-            
+
           , test "concating an empty list gives an empty stack" <|
-              \() -> 
+              \() ->
                   Expect.equal
                     Stack.empty
                     (Stack.concat [])
@@ -221,11 +221,23 @@ tests =
                   Expect.equal
                     (List.map ((+) 1) xs |> Stack.fromList)
                     (Stack.fromList xs |> Stack.map ((+) 1))
-          
-          , test "mapping an empty stack should result in an empty stack" <| 
+
+          , test "mapping an empty stack should result in an empty stack" <|
               \() ->
                   Expect.equal
                     Stack.empty
                     (Stack.map (always "foobar") Stack.empty)
+          ]
+    , describe "filter"
+          [ fuzz (list int) "filter (always True) satisfies identity law" <|
+              \xs ->
+                  Stack.fromList xs
+                    |> Stack.filter (always True)
+                    |> Expect.equal (Stack.fromList xs)
+          , test "result stack doesn't contain items which doesn't satisfy the predicate" <|
+              \() ->
+                  Stack.fromList [1,2,3]
+                    |> Stack.filter ((<) 1)
+                    |> Expect.equal (Stack.fromList [2,3])
           ]
     ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -234,7 +234,7 @@ tests =
                   Stack.fromList xs
                     |> Stack.filter (always True)
                     |> Expect.equal (Stack.fromList xs)
-          , test "result stack doesn't contain items which doesn't satisfy the predicate" <|
+          , test "result stack doesn't contain items which don't satisfy the predicate" <|
               \() ->
                   Stack.fromList [1,2,3]
                     |> Stack.filter ((<) 1)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -239,5 +239,9 @@ tests =
                   Stack.fromList [1,2,3]
                     |> Stack.filter ((<) 1)
                     |> Expect.equal (Stack.fromList [2,3])
+          , fuzz bool "filtering empty stack gives back empty stack" <|
+              \bool ->
+                  Stack.filter (always bool) Stack.empty
+                    |> Expect.equal (Stack.fromList [])
           ]
     ]


### PR DESCRIPTION
Hi! I would like to use this library but I'm missing filter function (which arguably could be worked around by using toList and fromList) but that seems a bit wasteful.

I also noticed some of the documentation is outdated since `Stack` now also contains the length in constructor so I made these updates as well.